### PR TITLE
Generic Repository that return IQuarable

### DIFF
--- a/src/CleanArchitecture.Core/Data/IGenericRepository.cs
+++ b/src/CleanArchitecture.Core/Data/IGenericRepository.cs
@@ -1,5 +1,5 @@
 ﻿using CleanArchitecture.Core.Data.Entity;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace CleanArchitecture.Core.Data
@@ -7,7 +7,9 @@ namespace CleanArchitecture.Core.Data
     public interface IGenericRepository<TEntity>
     where TEntity : class, IEntity
     {
-        IQueryable<TEntity> GetAll();
+        Task<IEnumerable<TEntity>> GetAll();
+
+        Task<IEnumerable<TEntity>> GetPaginated(int page, int size);
 
         Task<TEntity> GetById(int id);
 

--- a/src/CleanArchitecture.Core/Service/ArticleCategoryService.cs
+++ b/src/CleanArchitecture.Core/Service/ArticleCategoryService.cs
@@ -26,7 +26,7 @@ namespace CleanArchitecture.Core.Service
         public async Task<IEnumerable<ArticleCategoryDTO>> ListAllArticleCategoriesAsync()
         {
             var entities =
-                await _repo.GetAll().ToListAsync();
+                await _repo.GetAll();
 
             return entities
                 .Select(e => _mapper.Map<ArticleCategoryEntity, ArticleCategoryDTO>(e));

--- a/src/CleanArchitecture.Core/Service/ArticleService.cs
+++ b/src/CleanArchitecture.Core/Service/ArticleService.cs
@@ -6,12 +6,11 @@ using CleanArchitecture.Core.Data;
 using CleanArchitecture.Core.Data.DTO;
 using CleanArchitecture.Core.Data.Entity;
 using CleanArchitecture.Core.Extensions;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Hosting;
 using System.IO;
 using AutoMapper;
 using CleanArchitecture.Core.Logging;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 
 namespace CleanArchitecture.Core.Service
 {
@@ -39,8 +38,8 @@ namespace CleanArchitecture.Core.Service
         {
             try
             {
-                var articles =
-                    await _repo.GetAll().Take(10).ToListAsync();
+                var articles = await
+                    _repo.GetPaginated(1, 10);
 
                 _logger.LogInfo("Retrieved all Article Entities from ArticleService.");
 

--- a/src/CleanArchitecture.Infrastructure/Database/Repository/GenericRepository.cs
+++ b/src/CleanArchitecture.Infrastructure/Database/Repository/GenericRepository.cs
@@ -18,10 +18,20 @@ namespace CleanArchitecture.Infrastructure.Database.Repository
             _dbContext = dbContext;
         }
 
-        public IQueryable<TEntity> GetAll()
+        public async Task<IEnumerable<TEntity>> GetAll()
         {
-            return _dbContext.Set<TEntity>()
-                .AsNoTracking();
+            return await _dbContext.Set<TEntity>()
+                .AsNoTracking()
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<TEntity>> GetPaginated(int page, int size)
+        {
+            return await _dbContext.Set<TEntity>()
+                .Skip((page - 1) * size)
+                .Take(size)
+                .AsNoTracking()
+                .ToListAsync();
         }
 
         public async Task<TEntity> GetById(int id)


### PR DESCRIPTION
The idea of repositories are to encapsulate queries. This means that you must return a **list** of domain objects and not an IQuarable. For some more tips check out [this interesting read]( https://programmingwithmosh.com/net/common-mistakes-with-the-repository-pattern/).

Furthermore, I added a `GetPaginated` method which takes parameters (current)page, and size. This helps you to implement paginated views.